### PR TITLE
Add test for basedir existence

### DIFF
--- a/lib/r10k/environment/base.rb
+++ b/lib/r10k/environment/base.rb
@@ -36,7 +36,11 @@ class R10K::Environment::Base
     @basedir = basedir
     @dirname = dirname
     @options = options
-
+    begin
+      File.directory?(@basedir)
+    rescue
+      logger.fatal("Environment basedir error, can't find puppet environment basedir: '#{@basedir}'")
+    end
     @full_path = File.join(@basedir, @dirname)
     @path = Pathname.new(File.join(@basedir, @dirname))
     @puppetfile  = R10K::Puppetfile.new(@full_path)


### PR DESCRIPTION
I had a situation where following the r10k tutorial here (after using the PE installer):

http://docs.puppetlabs.com/pe/latest/quick_start_r10k.html

It states that if basedir isn't specified then it should default to the puppet $environmentpath and in my environment it didn't do that for some reason and would throw the following error:

ERROR	 -> no implicit conversion of nil into String

This isn't a very clear error and it took me quite a bit of time to figure out what it was trying to do.  This is coming from environment/base.rb on line 40 when it tries to do a join on the basedir and the dirname for the environment.

Environment details:
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=14.04
DISTRIB_CODENAME=trusty
DISTRIB_DESCRIPTION="Ubuntu 14.04.3 LTS"

R10k: r10k 2.0.2

This is the trace from when it is broken:

[2015-09-24 11:06:03 - DEBUG1] Testing to see if feature shellgit is available.
[2015-09-24 11:06:03 - DEBUG2] Evaluating proc #<Proc:0x0000000099f5e8@/opt/puppetlabs/puppet/lib/ruby/gems/2.1.0/gems/r10k-2.0.2/lib/r10k/features.rb:16> to test for feature shellgit
[2015-09-24 11:06:03 - DEBUG2] Proc #<Proc:0x0000000099f5e8@/opt/puppetlabs/puppet/lib/ruby/gems/2.1.0/gems/r10k-2.0.2/lib/r10k/features.rb:16> for feature shellgit returned "/usr/bin/git"
[2015-09-24 11:06:03 - DEBUG1] Feature shellgit is available.
[2015-09-24 11:06:03 - DEBUG1] Testing to see if feature shellgit is available.
[2015-09-24 11:06:03 - DEBUG2] Evaluating proc #<Proc:0x0000000099f5e8@/opt/puppetlabs/puppet/lib/ruby/gems/2.1.0/gems/r10k-2.0.2/lib/r10k/features.rb:16> to test for feature shellgit
[2015-09-24 11:06:03 - DEBUG2] Proc #<Proc:0x0000000099f5e8@/opt/puppetlabs/puppet/lib/ruby/gems/2.1.0/gems/r10k-2.0.2/lib/r10k/features.rb:16> for feature shellgit returned "/usr/bin/git"
[2015-09-24 11:06:03 - DEBUG1] Feature shellgit is available.
[2015-09-24 11:06:03 - DEBUG] Fetching 'git@gitlab.ah.lab:puppet/puppet-control' to determine current branches.
[2015-09-24 11:06:03 - DEBUG2] Starting process: ["git", "--git-dir", "/var/cache/r10k/git@gitlab.ah.lab-puppet-puppet-control", "fetch", "--prune"]
[2015-09-24 11:06:04 - DEBUG2] Finished process:
Command: git --git-dir /var/cache/r10k/git@gitlab.ah.lab-puppet-puppet-control fetch --prune
Exit code: 0
[2015-09-24 11:06:04 - DEBUG2] Starting process: ["git", "--git-dir", "/var/cache/r10k/git@gitlab.ah.lab-puppet-puppet-control", "for-each-ref", "refs/heads", "--format", "%(refname)"]
[2015-09-24 11:06:04 - DEBUG2] Finished process:
Command: git --git-dir /var/cache/r10k/git@gitlab.ah.lab-puppet-puppet-control for-each-ref refs/heads --format %(refname)
Stdout:
refs/heads/production
Exit code: 0
[2015-09-24 11:06:04 - ERROR] no implicit conversion of nil into String
/opt/puppetlabs/puppet/lib/ruby/gems/2.1.0/gems/r10k-2.0.2/lib/r10k/environment/base.rb:40:in `join'
/opt/puppetlabs/puppet/lib/ruby/gems/2.1.0/gems/r10k-2.0.2/lib/r10k/environment/base.rb:40:in `initialize'
/opt/puppetlabs/puppet/lib/ruby/gems/2.1.0/gems/r10k-2.0.2/lib/r10k/environment/git.rb:36:in `initialize'
/opt/puppetlabs/puppet/lib/ruby/gems/2.1.0/gems/r10k-2.0.2/lib/r10k/source/git.rb:91:in `new'
/opt/puppetlabs/puppet/lib/ruby/gems/2.1.0/gems/r10k-2.0.2/lib/r10k/source/git.rb:91:in `block in generate_environments'
/opt/puppetlabs/puppet/lib/ruby/gems/2.1.0/gems/r10k-2.0.2/lib/r10k/source/git.rb:89:in `each'
/opt/puppetlabs/puppet/lib/ruby/gems/2.1.0/gems/r10k-2.0.2/lib/r10k/source/git.rb:89:in `generate_environments'
/opt/puppetlabs/puppet/lib/ruby/gems/2.1.0/gems/r10k-2.0.2/lib/r10k/source/git.rb:81:in `environments'
/opt/puppetlabs/puppet/lib/ruby/gems/2.1.0/gems/r10k-2.0.2/lib/r10k/deployment.rb:85:in `block in validate!'
/opt/puppetlabs/puppet/lib/ruby/gems/2.1.0/gems/r10k-2.0.2/lib/r10k/deployment.rb:84:in `each'
/opt/puppetlabs/puppet/lib/ruby/gems/2.1.0/gems/r10k-2.0.2/lib/r10k/deployment.rb:84:in `validate!'
/opt/puppetlabs/puppet/lib/ruby/gems/2.1.0/gems/r10k-2.0.2/lib/r10k/action/deploy/environment.rb:44:in `visit_deployment'
/opt/puppetlabs/puppet/lib/ruby/gems/2.1.0/gems/r10k-2.0.2/lib/r10k/action/visitor.rb:24:in `visit'
/opt/puppetlabs/puppet/lib/ruby/gems/2.1.0/gems/r10k-2.0.2/lib/r10k/deployment.rb:100:in `accept'
/opt/puppetlabs/puppet/lib/ruby/gems/2.1.0/gems/r10k-2.0.2/lib/r10k/action/deploy/environment.rb:30:in `call'
/opt/puppetlabs/puppet/lib/ruby/gems/2.1.0/gems/r10k-2.0.2/lib/r10k/action/runner.rb:30:in `call'
/opt/puppetlabs/puppet/lib/ruby/gems/2.1.0/gems/r10k-2.0.2/lib/r10k/action/cri_runner.rb:67:in `call'
/opt/puppetlabs/puppet/lib/ruby/gems/2.1.0/gems/cri-2.6.1/lib/cri/command_dsl.rb:223:in `block in runner'
/opt/puppetlabs/puppet/lib/ruby/gems/2.1.0/gems/cri-2.6.1/lib/cri/command.rb:298:in `call'
/opt/puppetlabs/puppet/lib/ruby/gems/2.1.0/gems/cri-2.6.1/lib/cri/command.rb:298:in `run_this'
/opt/puppetlabs/puppet/lib/ruby/gems/2.1.0/gems/cri-2.6.1/lib/cri/command.rb:251:in `run'
/opt/puppetlabs/puppet/lib/ruby/gems/2.1.0/gems/cri-2.6.1/lib/cri/command.rb:264:in `run'
/opt/puppetlabs/puppet/lib/ruby/gems/2.1.0/gems/cri-2.6.1/lib/cri/command.rb:264:in `run'
/opt/puppetlabs/puppet/lib/ruby/gems/2.1.0/gems/r10k-2.0.2/bin/r10k:7:in `<top (required)>'
/usr/local/bin/r10k:23:in `load'
/usr/local/bin/r10k:23:in `<main>'

I added a test for the basedir right before it tries to do the join, I am not sure this is the cleanest solution but now it gives an error before it dies and gives that nil error.